### PR TITLE
set URIencoding to UTF-8 in the port 8080 connector

### DIFF
--- a/templates/tomcat_server_xml.j2
+++ b/templates/tomcat_server_xml.j2
@@ -71,7 +71,7 @@
     -->
     <Connector port="{{ item.conn_port }}" protocol="HTTP/1.1"
                connectionTimeout="20000"
-               redirectPort="8443" />
+               redirectPort="8443" URIEncoding="UTF-8"/>
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
This setting may no longer be necessary, but in the past it has been crucial to getting Solr to correctly support indexing of languages other than English.
