### PR TITLE
added an LSB-style header to the init script

### DIFF
--- a/files/tomcat_init
+++ b/files/tomcat_init
@@ -5,7 +5,21 @@
 # chkconfig: - 90 10
 # description: Tomcat is a Java application Server.
 
+### BEGIN INIT INFO
+# Provides: a Tomcat instance
+# Required-Start: $network $syslog
+# Required-Stop: $network $syslog
+# Default-Start:
+# Default-Stop:
+# Short-Description: Start up the Tomcat server daemon
+# Description:       Tomcat is a Java application Server.
+#                    This service starts up the Tomcat server daemon.
+### END INIT INFO
+
 NAME=`/bin/basename $0`
+
+# if this is a symlink from rc#.d, the S## part is not useful, filter it out
+NAME=`/bin/sed 's/^S[0-9]*//g' <<< $NAME`
 
 # Source function library
 if [ -r /etc/sysconfig/${NAME} ] ; then


### PR DESCRIPTION
 added an LSB-style header to the init script so it only starts after the network is available, and tweaked the NAME variable handling to avoid problems with symlink names
