### PR TITLE
Disable revproxy feature

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Install rsync
+  yum:
+    name: rsync
+    state: present
+
 - name: Determine if Tomcat needs to be downloaded/unarchived
   stat: path=/usr/local/apache-tomcat-{{ tomcat_version }}
   register: tomcat_path

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,9 +129,9 @@
     mode: 0755
     state: "directory"
 
-- name: Put in place the Apache HTTPD reverse proxy vhost configs for each tomcat app
-  template:
-    src: "tomcat_revproxy_vhost.j2"
-    dest: "/etc/httpd/vhosts.d/tomcatapps.httpd.conf"
-  notify:
-    - restart httpd
+#- name: Put in place the Apache HTTPD reverse proxy vhost configs for each tomcat app
+#  template:
+#    src: "tomcat_revproxy_vhost.j2"
+#    dest: "/etc/httpd/vhosts.d/tomcatapps.httpd.conf"
+#  notify:
+#    - restart httpd


### PR DESCRIPTION
Not exactly an AJP feature, but for current iterations of the role, we'll want to disable the reverse proxy until further testing(e.g. add meta for apache, make sure dir exists, etc). The next iteration should contain a flag to trigger a reverse proxy instead of using it by default. Not every service managed by us requires a local reverse proxy.