### PR TITLE
Increase session and proxy timeouts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,6 +123,17 @@
     group: "{{ item.app_name }}"
   with_items: "{{ tomcat_applications }}"
 
+- name: set the Tomcat session timeout to a usefully huge number
+  lineinfile:
+    dest: "/usr/local/{{ item.app_name }}/conf/web.xml"
+    regexp: "<session-timeout>30</session-timeout>"
+    state: "present"
+    line: "<session-timeout>840</session-timeout>"
+    owner: "{{ item.app_name }}"
+    group: "{{ item.app_name }}"
+    mode: 0644
+  with_items: "{{ tomcat_applications }}"
+
 - name: Put in place the tomcat logroate configuration file
   template:
     src: "tomcat_logrotate.j2"

--- a/templates/tomcat_revproxy_vhost.j2
+++ b/templates/tomcat_revproxy_vhost.j2
@@ -40,9 +40,8 @@
 
 {% for app in tomcat_applications %}
   # {{ app.app_name }} tomcat app
-  ProxyPass /{{ app.rproxy_path }} http://localhost:{{ app.conn_port }}/{{ app.rproxy_path }}
+  ProxyPass /{{ app.rproxy_path }} http://localhost:{{ app.conn_port }}/{{ app.rproxy_path }} keepalive=on
   ProxyPassReverse /{{ app.rproxy_path }} http://localhost:{{ app.conn_port }}/{{ app.rproxy_path }}
-  ProxyTimeout 300
   <Location /{{ app.rproxy_path }}>
     Require all granted
   </Location>


### PR DESCRIPTION
- increase the default Tomcat session timeout from 30 minutes to 840
minutes
- remove the proxy timeout, and copy keepalive settings from our DSpace
Tomcat reverse proxy config

Connects UCLALibrary/amalgamated-samvera#166